### PR TITLE
Automatically Select Controlled Tokens

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -42,5 +42,7 @@
     "LMRTFY.EnableParchmentTheme": "Enable parchment theme",
     "LMRTFY.EnableParchmentThemeHint": "Enables the use of the stylized UI with a parchment look",
     "LMRTFY.SentNotification": "LMRTFY: Roll request sent to connected players",
-    "LMRTFY.NothingNotification": "LMRTFY: Nothing to request"
+    "LMRTFY.NothingNotification": "LMRTFY: Nothing to request",
+    "LMRTFY.DeselectOnRequestorRender": "Deselect tokens when opening requestor",
+    "LMRTFY.DeselectOnRequestorRenderHint": "Enable to prevent roll requests from being sent to GM user (yourself)"
 }

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -9,6 +9,15 @@ class LMRTFY {
         default: true,
         onChange: (value) => LMRTFY.onThemeChange(value)
       });
+      
+      Handlebars.registerHelper('controlledToken', function (actor) {
+        const activeToken = actor.getActiveTokens()[0];
+        if (activeToken) {
+            return activeToken._controlled;
+        } else {
+            return false;
+        }
+      });
     }
 
     static ready() {

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -9,6 +9,15 @@ class LMRTFY {
         default: true,
         onChange: (value) => LMRTFY.onThemeChange(value)
       });
+      game.settings.register('lmrtfy', 'deselectOnRequestorRender', {
+        name: 'Deselect all controlled tokens when requestor is rendered', // localization + editing
+        hint: '',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        onChange: () => window.location.reload()
+      });
       
       Handlebars.registerHelper('lmrtfy-controlledToken', function (actor) {
         const activeToken = actor.getActiveTokens()[0];
@@ -58,6 +67,12 @@ class LMRTFY {
             LMRTFY.disadvantageRollEvent = { shiftKey: false, altKey: false, ctrlKey: true };
             LMRTFY.queryRollEvent = { shiftKey: false, altKey: false, ctrlKey: false };
             LMRTFY.specialRolls = { 'initiative': true, 'deathsave': true };
+        }
+
+        if (game.settings.get('lmrtfy', 'deselectOnRequestorRender')) {
+            Hooks.on("renderLMRTFYRequestor", () => {
+                canvas.tokens.releaseAll();
+            })
         }
     }
 

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -10,7 +10,7 @@ class LMRTFY {
         onChange: (value) => LMRTFY.onThemeChange(value)
       });
       
-      Handlebars.registerHelper('controlledToken', function (actor) {
+      Handlebars.registerHelper('lmrtfy-controlledToken', function (actor) {
         const activeToken = actor.getActiveTokens()[0];
         if (activeToken) {
             return activeToken._controlled;

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -10,12 +10,12 @@ class LMRTFY {
         onChange: (value) => LMRTFY.onThemeChange(value)
       });
       game.settings.register('lmrtfy', 'deselectOnRequestorRender', {
-        name: 'Deselect all controlled tokens when requestor is rendered', // localization + editing
-        hint: '',
+        name: game.i18n.localize('LMRTFY.DeselectOnRequestorRender'),
+        hint: game.i18n.localize('LMRTFY.DeselectOnRequestorRenderHint'),
         scope: 'world',
         config: true,
         type: Boolean,
-        default: true,
+        default: false,
         onChange: () => window.location.reload()
       });
       

--- a/templates/request-rolls.html
+++ b/templates/request-rolls.html
@@ -20,7 +20,7 @@
         <div class="form-group lmrtfy-actor-avatars">
         {{#each actors}}
             <div class="lmrtfy-actor" data-id="{{this.id}}">
-                <input type="checkbox" name="actor-{{this.id}}" id="lmrtf-actor-{{this.id}}" data-dtype="Boolean" checked />
+                <input type="checkbox" name="actor-{{this.id}}" id="lmrtf-actor-{{this.id}}" data-dtype="Boolean" {{#if (controlledToken this)}}checked{{/if}} />
                 <label for="lmrtf-actor-{{this.id}}"><img src="{{this.img}}" /></label>
             </div>
         {{/each}}

--- a/templates/request-rolls.html
+++ b/templates/request-rolls.html
@@ -20,7 +20,7 @@
         <div class="form-group lmrtfy-actor-avatars">
         {{#each actors}}
             <div class="lmrtfy-actor" data-id="{{this.id}}">
-                <input type="checkbox" name="actor-{{this.id}}" id="lmrtf-actor-{{this.id}}" data-dtype="Boolean" {{#if (controlledToken this)}}checked{{/if}} />
+                <input type="checkbox" name="actor-{{this.id}}" id="lmrtf-actor-{{this.id}}" data-dtype="Boolean" {{#if (lmrtfy-controlledToken this)}}checked{{/if}} />
                 <label for="lmrtf-actor-{{this.id}}"><img src="{{this.img}}" /></label>
             </div>
         {{/each}}


### PR DESCRIPTION
Adds a basic Handlebars helper to LMRTFY.init().
Adds a #if block to request-rolls.html template.

When the roll request dialog is rendered, tokens that were controlled will be automatically selected in the application.
Addresses issue #46 .

One known drawback is changing the User Select will not change which actors are selected.
Ideally, selecting a player with the User Select would automatically select their actor(s) as well.
Dynamic selection should be possible... though slightly outside my comfort zone.

(enso#0361)