### PR TITLE
instead of replacing the event, use the event for normal rolls

### DIFF
--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -20,10 +20,10 @@ class LMRTFY {
             LMRTFY.abilities = CONFIG.PF2E.abilities;
             LMRTFY.skills = CONFIG.PF2E.skills;
             LMRTFY.saves = CONFIG.PF2E.saves;
-            LMRTFY.normalRollEvent  = { shiftKey: false, altKey: false, ctrlKey: false };
+            LMRTFY.normalRollEvent  = { shiftKey: false, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.advantageRollEvent = { shiftKey: false, altKey: true, ctrlKey: false };
             LMRTFY.disadvantageRollEvent = { shiftKey: false, altKey: false, ctrlKey: true };
-            LMRTFY.queryRollEvent = { shiftKey: true, altKey: false, ctrlKey: false };
+            LMRTFY.queryRollEvent = { shiftKey: true, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.specialRolls = { 'initiative': true, 'deathsave': true, 'perception': true };
         } else if(game.system.id == "D35E") {
             LMRTFY.saveRollMethod = 'rollSave';
@@ -32,10 +32,10 @@ class LMRTFY {
             LMRTFY.abilities = CONFIG.D35E.abilities;
             LMRTFY.skills = CONFIG.D35E.skills;
             LMRTFY.saves = CONFIG.D35E.savingThrows;
-            LMRTFY.normalRollEvent  = { shiftKey: false, altKey: false, ctrlKey: false };
+            LMRTFY.normalRollEvent  = { shiftKey: false, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.advantageRollEvent = { shiftKey: false, altKey: true, ctrlKey: false };
             LMRTFY.disadvantageRollEvent = { shiftKey: false, altKey: false, ctrlKey: true };
-            LMRTFY.queryRollEvent = { shiftKey: true, altKey: false, ctrlKey: false };
+            LMRTFY.queryRollEvent = { shiftKey: true, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.specialRolls = { 'initiative': true, 'deathsave': false, 'perception': true };
         } else {
             LMRTFY.saveRollMethod = 'rollAbilitySave';
@@ -44,10 +44,10 @@ class LMRTFY {
             LMRTFY.abilities = CONFIG.DND5E.abilities;
             LMRTFY.skills = CONFIG.DND5E.skills;
             LMRTFY.saves = CONFIG.DND5E.abilities;
-            LMRTFY.normalRollEvent  = { shiftKey: true, altKey: false, ctrlKey: false };
+            LMRTFY.normalRollEvent  = { shiftKey: true, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.advantageRollEvent = { shiftKey: false, altKey: true, ctrlKey: false };
             LMRTFY.disadvantageRollEvent = { shiftKey: false, altKey: false, ctrlKey: true };
-            LMRTFY.queryRollEvent = { shiftKey: false, altKey: false, ctrlKey: false };
+            LMRTFY.queryRollEvent = { shiftKey: false, altKey: false, ctrlKey: false }; // @deprecated
             LMRTFY.specialRolls = { 'initiative': true, 'deathsave': true };
         }
     }

--- a/src/roller.js
+++ b/src/roller.js
@@ -115,13 +115,13 @@ class LMRTFYRoller extends Application {
                 fakeEvent = LMRTFY.disadvantageRollEvent;
                 break;
             case 0:
-                fakeEvent = LMRTFY.normalRollEvent;
+                fakeEvent = event;
                 break;
             case 1:
                 fakeEvent = LMRTFY.advantageRollEvent;
                 break;
             case 2: 
-                fakeEvent = LMRTFY.queryRollEvent;
+                fakeEvent = event;
                 break;
         }
         const rollMode = game.settings.get("core", "rollMode");


### PR DESCRIPTION
Resolves #41 

Tested with PF2 and dnd5e, passing the event shouldn't cause issues.