### PR TITLE
Fix Death Saving Throws for dnd5e

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -36,7 +36,7 @@
     "LMRTFY.DeathSave": "Death Save",
     "LMRTFY.Perception": "Perception",
     "LMRTFY.InitiativeRollMessage": "Roll for Initiative!",
-    "LMRTFY.DeathSaveRollMessage": "Death Savings Throw",
+    "LMRTFY.DeathSaveRollMessage": "Death Saving Throw",
     "LMRTFY.PerceptionRollMessage": "Perception Check",
     "LMRTFY.Extras": "Extras",
     "LMRTFY.EnableParchmentTheme": "Enable parchment theme",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "lmrtfy",
     "title": "Let Me Roll That For You!",
     "description": "Ask your players to make rolls for you.",
-    "version": "1.9",
+    "version": "1.9.1",
     "author": "KaKaRoTo, iotech, Limping Ninja, Rughalt, Calego",
     "scripts": [
         "./src/lmrtfy.js",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "lmrtfy",
     "title": "Let Me Roll That For You!",
     "description": "Ask your players to make rolls for you.",
-    "version": "1.9.1",
+    "version": "1.9",
     "author": "KaKaRoTo, iotech, Limping Ninja, Rughalt, Calego",
     "scripts": [
         "./src/lmrtfy.js",

--- a/src/roller.js
+++ b/src/roller.js
@@ -286,7 +286,16 @@ class LMRTFYRoller extends Application {
     }
     _onDeathSave(event) {
         event.preventDefault();
-        this._makeDiceRoll(event, "1d20", game.i18n.localize("LMRTFY.DeathSaveRollMessage"));
+        if(game.system.id == "dnd5e") {
+            for (let actor of this.actors) {
+                actor.rollDeathSave(event);
+            }
+            event.currentTarget.disabled = true;
+            if (this.element.find("button").filter((i, e) => !e.disabled).length === 0)
+                this.close();
+        } else {
+            this._makeDiceRoll(event, "1d20", game.i18n.localize("LMRTFY.DeathSaveRollMessage"));
+        }
     }
 
     _onPerception(event) {


### PR DESCRIPTION
Resolves #69 

Proposed fix for https://github.com/League-of-Foundry-Developers/fvtt-module-lmrtfy/issues/69 by rolling Death Saves using actor.rollDeathSave similarly to how Initiative is handled with actor.rollInitiative.