### PR TITLE
Disabling special perception on pf1e

### DIFF
--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -58,7 +58,7 @@ class LMRTFY {
                 LMRTFY.normalRollEvent = { shiftKey: false, altKey: false, ctrlKey: false };
                 LMRTFY.advantageRollEvent = { shiftKey: false, altKey: true, ctrlKey: false };
                 LMRTFY.disadvantageRollEvent = { shiftKey: false, altKey: false, ctrlKey: true };
-                LMRTFY.specialRolls = { 'initiative': true, 'deathsave': false, 'perception': true };
+                LMRTFY.specialRolls = { 'initiative': true, 'deathsave': false, 'perception': false };
                 break;
 
             case 'pf2e':

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -49,7 +49,7 @@ class LMRTFY {
                 break;
 
             case 'pf1':
-                LMRTFY.saveRollMethod = 'rollSave';
+                LMRTFY.saveRollMethod = 'rollSavingThrow';
                 LMRTFY.abilityRollMethod = 'rollAbility';
                 LMRTFY.skillRollMethod = 'rollSkill';
                 LMRTFY.abilities = CONFIG.PF1.abilities;

--- a/src/roller.js
+++ b/src/roller.js
@@ -272,7 +272,7 @@ class LMRTFYRoller extends Application {
     }
     _onInitiative(event) {
         event.preventDefault();
-        if(game.system.id == "dnd5e") {
+        if(this.data.initiative) {
             for (let actor of this.actors) {
                 actor.rollInitiative();
             }


### PR DESCRIPTION
The special perception doesn't use the correct info on pf1e, so disabling while I figure out how to make it better.