### PR TITLE
Update request-rolls.html

### DIFF
--- a/templates/request-rolls.html
+++ b/templates/request-rolls.html
@@ -94,7 +94,7 @@
             {{#each abilities as |name key|}}
             <div class="lmrtfy-ability">
                 <input type="checkbox" name="check-{{key}}" id="lmrtf-check-{{key}}" data-dtype="Boolean" />
-                <label for="lmrtf-check-{{key}}">{{name}}</label>
+                <label for="lmrtf-check-{{key}}">{{localize name}}</label>
                 
             </div>
             {{/each}}
@@ -110,7 +110,7 @@
             {{#each saves as |name key|}}
             <div class="lmrtfy-ability">
                 <input type="checkbox" name="save-{{key}}" id="lmrtf-save-{{key}}" data-dtype="Boolean" />
-                <label for="lmrtf-save-{{key}}">{{name}}</label>            
+                <label for="lmrtf-save-{{key}}">{{localize name}}</label>            
             </div>
             {{/each}}
         </div>
@@ -124,7 +124,7 @@
                 {{#each skills as |name key|}}
                 <div class="lmrtfy-skill">
                     <input type="checkbox" name="skill-{{key}}" id="lmrtf-skill-{{key}}" data-dtype="Boolean" />
-                    <label for="lmrtf-skill-{{key}}">{{name}}</label>
+                    <label for="lmrtf-skill-{{key}}">{{localize name}}</label>
                 </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
fix name for ability score/saves/skills to be localized to account for changes in pf2e system.  Tested in pf2e and dnd5e (since dnd5e is most widely used system)

fixes #92