### PR TITLE
Fix visibility rolls on Abilities, Saves & Skills

### DIFF
--- a/src/roller.js
+++ b/src/roller.js
@@ -112,7 +112,7 @@ class LMRTFYRoller extends Application {
         }
     }
 
-    _makeRoll(event, rollMethod, ...args) {
+    async _makeRoll(event, rollMethod, ...args) {
         let fakeEvent = {}
         switch(this.advantage) {
             case -1: 
@@ -139,11 +139,11 @@ class LMRTFYRoller extends Application {
             // system specific roll handling
             switch (game.system.id) {
                 case "pf2e": {
-                    actor[rollMethod].call(actor, fakeEvent, ...args);
+                    await actor[rollMethod].call(actor, fakeEvent, ...args);
                     break;
                 }
                 default: {
-                    actor[rollMethod].call(actor, ...args, { event: fakeEvent });
+                    await actor[rollMethod].call(actor, ...args, { event: fakeEvent });
                 }
             }
         }


### PR DESCRIPTION
On 0.8.x the roll takes longer than the roll mode. So it changes it to the specified roll (blind etc) but before the roll is resolved, the rollmode is changed back to what it was. As such it's not rolling in the correct mode. I changed the _makeRoll function to an async function and the call to the actor's roll method added an await. This allows the roll to be resolved before the roll mode is changed back to the previous one

We'll have to contact midi-qol to also implement the async - await change on his patching function. I'll create a ticket on the module.