### PR TITLE
Fix for pf2e 3.2.0 changes

### DIFF
--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -240,10 +240,8 @@ class LMRTFY {
             .reduce((rules, item) => rules.concat(game.pf2e.RuleElements.fromOwnedItem(item)), [])
             .filter((rule) => !rule.ignored);
 
-        const { statisticsModifiers } = actor.prepareCustomModifiers(rules);
-        
         [`${ability}-based`, 'ability-check', 'all'].forEach((key) => {
-            (statisticsModifiers[key] || []).map((m) => duplicate(m)).forEach((m) => modifiers.push(m));
+            (actor.synthetics.statisticsModifier[key] || []).map((m) => duplicate(m)).forEach((m) => modifiers.push(m));
         });
         
         return new game.pf2e.StatisticModifier(`${game.i18n.localize('LMRTFY.AbilityCheck')} ${game.i18n.localize(mod.label)}`, modifiers);


### PR DESCRIPTION
prepareCustomModifiers was changed to private, but the statistics modifiers are available under actor.synthetics. Seems to work for me.