### PR TITLE
Fix pf2e cloned statisticsModifier type

### DIFF
--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -236,10 +236,6 @@ class LMRTFY {
         const mod = game.pf2e.AbilityModifier.fromScore(ability, actor.data.data.abilities[ability].value);
         modifiers.push(mod);
 
-        const rules = actor.items
-            .reduce((rules, item) => rules.concat(game.pf2e.RuleElements.fromOwnedItem(item)), [])
-            .filter((rule) => !rule.ignored);
-
         [`${ability}-based`, 'ability-check', 'all'].forEach((key) => {
             (actor.synthetics.statisticsModifier[key] || []).forEach((m) => modifiers.push(m.clone()));
         });

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -241,7 +241,7 @@ class LMRTFY {
             .filter((rule) => !rule.ignored);
 
         [`${ability}-based`, 'ability-check', 'all'].forEach((key) => {
-            (actor.synthetics.statisticsModifier[key] || []).map((m) => duplicate(m)).forEach((m) => modifiers.push(m));
+            (actor.synthetics.statisticsModifier[key] || []).forEach((m) => modifiers.push(m.clone()));
         });
         
         return new game.pf2e.StatisticModifier(`${game.i18n.localize('LMRTFY.AbilityCheck')} ${game.i18n.localize(mod.label)}`, modifiers);


### PR DESCRIPTION
With duplicate the modifiers are no longer ModifierPF2e, which can cause problems - use the ModifierPF2e.clone() method instead, to create a correctly cloned instance.

Edit: Also remove no longer needed rules section