### PR TITLE
Prevent errors from occurring when the message data is malformed.

### DIFF
--- a/src/roller.js
+++ b/src/roller.js
@@ -262,7 +262,7 @@ class LMRTFYRoller extends Application {
                         actor: speaker.actor,
                     },
                     flavor: this.message || defaultMessage,
-                }
+                };
 
                 chatMessages.push(messageData);
             } catch(err) {

--- a/src/roller.js
+++ b/src/roller.js
@@ -251,10 +251,10 @@ class LMRTFYRoller extends Application {
             try {
                 const rollData = actor.getRollData();
                 const roll = new Roll(formula, rollData);
+                const speaker = ChatMessage.getSpeaker({actor: actor});
                 const rollMessageData = await roll.toMessage({"flags.lmrtfy": messageFlag}, {rollMode: this.mode, create: false});
                 
-                const speaker = ChatMessage.getSpeaker({actor: actor});
-                const messageData = mergeObject(rollMessageData, {
+                const messageData = { ...(await roll.toMessage({"flags.lmrtfy": messageFlag}, {rollMode: this.mode, create: false})),
                     speaker: {
                         alias: speaker.alias,
                         scene: speaker.scene,
@@ -262,10 +262,11 @@ class LMRTFYRoller extends Application {
                         actor: speaker.actor,
                     },
                     flavor: this.message || defaultMessage,
-                });
+                }
 
                 chatMessages.push(messageData);
             } catch(err) {
+                console.error(err);
                 continue;
             }
         }


### PR DESCRIPTION
On some builds the dice roll will fail due to the messageData object not having the update method. This will cause the dice roll to fail without any information being passed back to the end user. I found on the latest V9 update, this issue was becoming quite prevalent as my world and a friend's world encountered it. This change makes it so even if it fails, the user will get a console log to see what went wrong.