### PR TITLE
Enable support for "Old School Essentials"

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,7 +22,8 @@
         "sw5e",
         "cof",
         "coc",
-        "demonlord"
+        "demonlord",
+        "ose"
     ],
     "languages": [
         {

--- a/src/lmrtfy.js
+++ b/src/lmrtfy.js
@@ -147,6 +147,24 @@ class LMRTFY {
                 LMRTFY.abilityModifiers = {};
                 break;
 
+            case 'ose':
+                LMRTFY.saveRollMethod = 'rollSave';
+                LMRTFY.abilityRollMethod = 'rollCheck';
+                LMRTFY.skillRollMethod = 'rollExploration';
+                LMRTFY.abilities = CONFIG.OSE.scores;
+                LMRTFY.abilityAbbreviations = CONFIG.OSE.scores_short;
+                LMRTFY.skills = CONFIG.OSE.exploration_skills;
+                LMRTFY.saves = CONFIG.OSE.saves_long;
+                LMRTFY.normalRollEvent = {};
+                LMRTFY.advantageRollEvent = {};
+                LMRTFY.disadvantageRollEvent = {};
+                LMRTFY.modIdentifier = 'mod';
+                LMRTFY.abilityModifiers = LMRTFY.parseAbilityModifiers();
+                LMRTFY.specialRolls = {};
+                LMRTFY.modIdentifier = 'modifier';
+                LMRTFY.abilityModifiers = {};
+                break;
+
             default:
                 console.error('LMRFTY | Unsupported system detected');
 


### PR DESCRIPTION
Hello, we're preparing our 1.3.7 release for the Old School Essential system, which integrates a few needed change to enable support for LMGTFY, and here's my contribution to enable rolls for the standard rolls (Abilities, Saves and Exploration checks) :)

